### PR TITLE
Summary: minor fix for input data with rollover extent and zero allocated landuse class, added timestamp to GLOBIO log entries in light of allocation debugging

### DIFF
--- a/Calculations/GLOBIO_CalcDiscreteLanduseAllocationScenSuit.py
+++ b/Calculations/GLOBIO_CalcDiscreteLanduseAllocationScenSuit.py
@@ -366,6 +366,8 @@ class GLOBIO_CalcDiscreteLanduseAllocationScenSuit(CalculationBase):
       # Get landuse types in region.
       luTypes = np.unique(landuseRaster.r[regionMask])
       # Calculate sum of areas per landuse type.
+      if luTypes.nbytes==0:
+        continue
       areaSum = scipy.ndimage.labeled_comprehension(areaRaster.r[regionMask],
                                                     landuseRaster.r[regionMask],
                                                     luTypes,np.sum,np.float64,0)
@@ -1467,7 +1469,7 @@ class GLOBIO_CalcDiscreteLanduseAllocationScenSuit(CalculationBase):
     notAllocatedMask = (outRaster.r == outRaster.noDataValue)
     
     # Fill output with land-cover.
-    outRaster.r[notAllocatedMask] = landcoverRaster.r[notAllocatedMask]
+    # outRaster.r[notAllocatedMask] = landcoverRaster.r[notAllocatedMask] # TODO: temporarily disabled
 
     # Close and free the land-cover raster.
     landcoverRaster.close()

--- a/Core/Logger.py
+++ b/Core/Logger.py
@@ -20,6 +20,7 @@
 #-------------------------------------------------------------------------------
 
 import os
+from datetime import datetime
 
 import GlobioModel.Core.Error as Err
 import GlobioModel.Core.Globals as GLOB
@@ -188,7 +189,10 @@ class Logger(object):
       with open(fileName,"a") as logFile:
         if not s.endswith("\n"):
           s += "\n"
-        logFile.write(s)
+
+        message_time = datetime.now()
+        
+        logFile.write(message_time.strftime("%Y-%m-%d %H:%M:%S") + s)
     except:
       pass
 

--- a/Core/Raster.py
+++ b/Core/Raster.py
@@ -1328,15 +1328,15 @@ class Raster(object):
     #Log.dbg("Overlap NrCols/NrRows: %s %s" % (overlapNrCols,overlapNrRows))
 
     # Calculate upper left col/row of overlap extent in raster.
-    minC1,minR1 = RU.calcColRowFromXY(overlapExtent[0],overlapExtent[3]-self.cellSize,
+    minC1,minR1 = RU.calcColRowFromXY(overlapExtent[0],overlapExtent[3],
                                       self.extent,self.cellSize) 
 
     #Log.dbg("Org rows/cols: %s,%s %s,%s" % (minR1,minC1,minR1+overlapNrRows,minC1+overlapNrCols))
 
     # Calculate upper left col/row of overlap extent in new raster.
-    minC2,minR2 = RU.calcColRowFromXY(overlapExtent[0],overlapExtent[3]-self.cellSize,
+    minC2,minR2 = RU.calcColRowFromXY(overlapExtent[0],overlapExtent[3],
                                       toExtent,self.cellSize) 
-  
+    
     #Log.dbg("Org rows/cols: %s,%s %s,%s" % (minR2,minC2,minR2+overlapNrRows,minC2+overlapNrCols))
     #Log.dbg("[%s:%s,%s:%s] [%s:%s,%s:%s]" % (minR2,minR2+overlapNrRows,minC2,minC2+overlapNrCols,
     #                                         minR1,minR1+overlapNrRows,minC1,minC1+overlapNrCols))


### PR DESCRIPTION
format: "%Y-%m-%d %H:%M:%S" ie. 2023-12-31 10:40:12